### PR TITLE
Allow to pass raw Bytes instead of 16 bit registers

### DIFF
--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -98,11 +98,13 @@ exports.bitsToBuffer = function bitsToBuffer(bits) {
 };
 
 exports.blocksToBuffer = function blocksToBuffer(blocks) {
-
 	if (Buffer.isBuffer(blocks)) {
-		const buffer = Buff.alloc(blocks.length + 1);
+		var buffer = Buff.alloc(blocks.length + 1);
+
 		buffer[0] = blocks.length;
-		blocks.copy(buffer,1);
+
+		blocks.copy(buffer, 1);
+
 		return buffer;
 	}
 

--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -98,6 +98,14 @@ exports.bitsToBuffer = function bitsToBuffer(bits) {
 };
 
 exports.blocksToBuffer = function blocksToBuffer(blocks) {
+
+	if (Buffer.isBuffer(blocks)) {
+		const buffer = Buff.alloc(blocks.length + 1);
+		buffer[0] = blocks.length;
+		blocks.copy(buffer,1);
+		return buffer;
+	}
+
 	var buffer = Buff.alloc((blocks.length * 2) + 1);
 
 	buffer.writeUInt8(blocks.length * 2, 0);

--- a/test/integration/read-holding-registers.js
+++ b/test/integration/read-holding-registers.js
@@ -31,4 +31,18 @@ describe("Read Holding Registers", function () {
 			}
 		}
 	});
+
+	it("should be [ address, quantity ] => buffer", function () {
+		for (var i = 0; i < Help.trials; i++) {
+			var address = Math.round(Math.random() * 100);
+			var blocks  = Help.randomBlock(7);
+
+			assert.deepEqual(
+				{ address : address, quantity : blocks.length },
+				Help.modbus.ReadHoldingRegisters.Request.parse(
+					Help.modbus.ReadHoldingRegisters.Request.build(address, blocks.length)
+				)
+			);
+		}
+	});
 });


### PR DESCRIPTION
Usage: reply(null,Buffer.from([0xAA,0xFF,0xFF,0xEE]);
Usefully for not fully Modbus compatible devices,
which want to have a odd number of bytes. 