### PR TITLE
Fixed tests to work on Node > 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+
 node_js:
   - "0.10"
   - "0.12"
@@ -6,3 +7,10 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
+  - "10"
+  - "11"
+  - "lts/*"
+  - "node"
+
+cache: npm

--- a/test/integration/read-coils.js
+++ b/test/integration/read-coils.js
@@ -19,7 +19,7 @@ describe("Read Coils", function () {
 					function () {
 						Help.modbus.ReadCoils.Response.build(bits)
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-coils.js
+++ b/test/integration/read-coils.js
@@ -19,7 +19,7 @@ describe("Read Coils", function () {
 					function () {
 						Help.modbus.ReadCoils.Response.build(bits)
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-discrete-inputs.js
+++ b/test/integration/read-discrete-inputs.js
@@ -19,7 +19,7 @@ describe("Read Discrete Inputs", function () {
 					function () {
 						Help.modbus.ReadDiscreteInputs.Response.build(bits)
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-discrete-inputs.js
+++ b/test/integration/read-discrete-inputs.js
@@ -19,7 +19,7 @@ describe("Read Discrete Inputs", function () {
 					function () {
 						Help.modbus.ReadDiscreteInputs.Response.build(bits)
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-file-record.js
+++ b/test/integration/read-file-record.js
@@ -25,7 +25,7 @@ describe("Read File Record", function () {
 					function () {
 						Help.modbus.ReadFileRecord.Request.build(req);
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(
@@ -41,7 +41,7 @@ describe("Read File Record", function () {
 					function () {
 						Help.modbus.ReadFileRecord.Response.build(res);
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-file-record.js
+++ b/test/integration/read-file-record.js
@@ -25,7 +25,7 @@ describe("Read File Record", function () {
 					function () {
 						Help.modbus.ReadFileRecord.Request.build(req);
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(
@@ -41,7 +41,7 @@ describe("Read File Record", function () {
 					function () {
 						Help.modbus.ReadFileRecord.Response.build(res);
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-holding-registers.js
+++ b/test/integration/read-holding-registers.js
@@ -19,7 +19,7 @@ describe("Read Holding Registers", function () {
 					function () {
 						Help.modbus.ReadHoldingRegisters.Response.build(blocks)
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-holding-registers.js
+++ b/test/integration/read-holding-registers.js
@@ -19,7 +19,7 @@ describe("Read Holding Registers", function () {
 					function () {
 						Help.modbus.ReadHoldingRegisters.Response.build(blocks)
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-input-registers.js
+++ b/test/integration/read-input-registers.js
@@ -19,7 +19,7 @@ describe("Read Input Registers", function () {
 					function () {
 						Help.modbus.ReadInputRegisters.Response.build(blocks)
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/read-input-registers.js
+++ b/test/integration/read-input-registers.js
@@ -19,7 +19,7 @@ describe("Read Input Registers", function () {
 					function () {
 						Help.modbus.ReadInputRegisters.Response.build(blocks)
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/write-file-record.js
+++ b/test/integration/write-file-record.js
@@ -29,7 +29,7 @@ describe("Write File Record", function () {
 					function () {
 						Help.modbus.WriteFileRecord.Request.build(req);
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(
@@ -45,7 +45,7 @@ describe("Write File Record", function () {
 					function () {
 						Help.modbus.WriteFileRecord.Request.build(req);
 					},
-					/out of (bounds|range)/
+					/(out of bounds|RangeError)/
 				);
 			} else {
 				assert.deepEqual(

--- a/test/integration/write-file-record.js
+++ b/test/integration/write-file-record.js
@@ -29,7 +29,7 @@ describe("Write File Record", function () {
 					function () {
 						Help.modbus.WriteFileRecord.Request.build(req);
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(
@@ -45,7 +45,7 @@ describe("Write File Record", function () {
 					function () {
 						Help.modbus.WriteFileRecord.Request.build(req);
 					},
-					/out of bounds/
+					/out of (bounds|range)/
 				);
 			} else {
 				assert.deepEqual(


### PR DESCRIPTION
The error messages have changed since Node v9 so the tests fail on all version >= 9.

This PR fixes the tests and adds TravisCI checks for newer Node versions including the current LTS and latest stable. The NPM cache was enabled as well.

Merging will allow tests from `modbus-stream` to pass on these node versions as well.