### PR TITLE
Remove fs dependency with explicit listing of files 

### DIFF
--- a/lib/Modbus.js
+++ b/lib/Modbus.js
@@ -1,4 +1,3 @@
-var fs        = require("fs");
 var util      = require("util");
 var path      = require("path");
 var Exception = require("./Exception");
@@ -28,7 +27,25 @@ exports.Helpers = {
 Exception.load(exports);
 
 function load() {
-	var files = fs.readdirSync(path.resolve(__dirname, "protocol"));
+	// List of request files in protocol subdir. 
+	var files =
+		["GET_COMM_EVENT_COUNTER.js",
+			"GET_COMM_EVENT_LOG.js",
+			"MASK_WRITE_REGISTER.js",
+			"READ_COILS.js",
+			"READ_DEVICE_IDENTIFICATION.js",
+			"READ_DISCRETE_INPUTS.js",
+			"READ_EXCEPTION_STATUS.js",
+			"READ_FIFO_QUEUE.js",
+			"READ_FILE_RECORD.js",
+			"READ_HOLDING_REGISTERS.js",
+			"READ_INPUT_REGISTERS.js",
+			"READ_WRITE_MULTIPLE_REGISTERS.js",
+			"WRITE_FILE_RECORD.js",
+			"WRITE_MULTIPLE_COILS.js",
+			"WRITE_MULTIPLE_REGISTERS.js",
+			"WRITE_SINGLE_COIL.js",
+			"WRITE_SINGLE_REGISTER.js"];
 
 	files.map(function (file) {
 		if (file.substr(file.length - 3) !== ".js") return;

--- a/lib/Modbus.js
+++ b/lib/Modbus.js
@@ -28,30 +28,29 @@ Exception.load(exports);
 
 function load() {
 	// List of request files in protocol subdir. 
-	var files =
-		["GET_COMM_EVENT_COUNTER.js",
-			"GET_COMM_EVENT_LOG.js",
-			"MASK_WRITE_REGISTER.js",
-			"READ_COILS.js",
-			"READ_DEVICE_IDENTIFICATION.js",
-			"READ_DISCRETE_INPUTS.js",
-			"READ_EXCEPTION_STATUS.js",
-			"READ_FIFO_QUEUE.js",
-			"READ_FILE_RECORD.js",
-			"READ_HOLDING_REGISTERS.js",
-			"READ_INPUT_REGISTERS.js",
-			"READ_WRITE_MULTIPLE_REGISTERS.js",
-			"WRITE_FILE_RECORD.js",
-			"WRITE_MULTIPLE_COILS.js",
-			"WRITE_MULTIPLE_REGISTERS.js",
-			"WRITE_SINGLE_COIL.js",
-			"WRITE_SINGLE_REGISTER.js"];
+	var files = [
+		"GET_COMM_EVENT_COUNTER",
+		"GET_COMM_EVENT_LOG",
+		"MASK_WRITE_REGISTER",
+		"READ_COILS",
+		"READ_DEVICE_IDENTIFICATION",
+		"READ_DISCRETE_INPUTS",
+		"READ_EXCEPTION_STATUS",
+		"READ_FIFO_QUEUE",
+		"READ_FILE_RECORD",
+		"READ_HOLDING_REGISTERS",
+		"READ_INPUT_REGISTERS",
+		"READ_WRITE_MULTIPLE_REGISTERS",
+		"WRITE_FILE_RECORD",
+		"WRITE_MULTIPLE_COILS",
+		"WRITE_MULTIPLE_REGISTERS",
+		"WRITE_SINGLE_COIL",
+		"WRITE_SINGLE_REGISTER",
+	];
 
 	files.map(function (file) {
-		if (file.substr(file.length - 3) !== ".js") return;
-
-		var funct     = require("./protocol/" + file);
-		var camelName = file[0].toUpperCase() + file.substr(1, file.length - 4).toLowerCase().replace(/_(\w)/g, function (m, c) {
+		var funct     = require("./protocol/" + file + ".js");
+		var camelName = file[0].toUpperCase() + file.substr(1).toLowerCase().replace(/_(\w)/g, function (m, c) {
 			return c.toUpperCase();
 		});
 


### PR DESCRIPTION
There is no easy replacement for fs in the browsers.
I needed this node.js module, to run it client-side with webpack.
Since FS is used only to enumerate files, I propose this fix to remove the fs dependency.

This is my webpack.config.js that allows to build it with process/path-browserify dependencies.

```
const path = require('path');
const webpack = require('webpack');

module.exports = {
  entry: './js/main.js',
  mode: "development",
  output: {
    filename: 'bundle.js',
    path: path.resolve(__dirname, 'dist'),
  },
  plugins: [
      new webpack.ProvidePlugin({
        process: 'process/browser',
        Buffer: ['buffer', 'Buffer'],
      }) ],
  resolve: {
      fallback: { 
		'path': require.resolve('path-browserify'),
		fs: false },
	extensions: ['.jsx', '.js', '.tsx', '.ts']
  }
};
```